### PR TITLE
Build and Deploy Script

### DIFF
--- a/builddeploy
+++ b/builddeploy
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+compileCommand="mbed-cli compile -j0 -t GCC_ARM -m nucleo_f746zg --source .  --source ./mbed-os/features/unsupported/USBDevice/USBDevice/  --source ./mbed-os/features/unsupported/USBDevice/USBHID"
+
+outputFolder=""
+if [ -z "$1" ]; then
+  pip freeze | grep mbed-greentea
+  if [ "$?" = "0" ]; then
+    # If no specific directory is defined and greentea is here, do the thing
+    $compileCommand -f
+    exit
+  else
+    # greentea is not here, so go to default directory
+    outputFolder="/media/$USER/NUCLEO_*/"
+  fi
+else
+  # Directory is specified, bypass greentea
+  outputFolder="$1"
+fi
+
+tempFile='builddeploy.tmp'
+
+# Compile the code
+$compileCommand | tee "$tempFile"
+
+# Get the binary name from the build output
+binary="$(tail -n5 builddeploy.tmp | grep 'Image:' | cut -d " " -f 2)"
+
+echo "Deploying $binary to $outputFolder"
+
+# Clean up
+rm -f "$tempFile"
+
+# Deploys the binary to the output folder
+cp "$binary" $outputFolder
+
+echo 'Done'

--- a/builddeploy
+++ b/builddeploy
@@ -4,8 +4,7 @@ compileCommand="mbed-cli compile -j0 -t GCC_ARM -m nucleo_f746zg --source .  --s
 
 outputFolder=""
 if [ -z "$1" ]; then
-  pip freeze | grep mbed-greentea
-  if [ "$?" = "0" ]; then
+  if pip freeze | grep mbed-greentea ; then
     # If no specific directory is defined and greentea is here, do the thing
     $compileCommand -f
     exit


### PR DESCRIPTION
This scripts allows for a quicker way for users to build and deploy their code to the robot.  Instead of a really long `mbed-cli` command, use is now `./builddeploy [fname]` where `[fname]` is an optional folder name.  Without an argument, this script checks for `mbed-greentea` and if it is installed, will use it to deploy.  If not, it will copy the compiled binary to the robot in the default location in the ubuntu filesystem on the lab computers.  With an argument, the script ignores `mbed-greentea` and copies the compiled binary to that folder.

Example use-case for the optional `[fname]` argument: Windows Subsystem for Linux (WSL) does not support `udev`, which `mbed-greentea` uses.  Users can mount the robot into the ubuntu filesystem then deploy to it from WSL using this argument.